### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI - NestJS Build Only
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/onepiecehung/nest.js-postgresql/security/code-scanning/3](https://github.com/onepiecehung/nest.js-postgresql/security/code-scanning/3)

To fix this permissions error, we need to explicitly specify the permissions required by the workflow. Since all workflow steps are restricted to local build and test actions and do not need to push changes, interact with issues, or otherwise write to the repository, we can safely set the minimal permissions: `contents: read`. This can be done by adding a `permissions:` block at the root level of the workflow file (just below the `name:` and before `on:` or `jobs:`), which will apply to all jobs unless individually overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
