### PR TITLE
Enhance Slug Generation in ArticlesService for Unique Article Identif…

### DIFF
--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -211,10 +211,14 @@ export class ArticlesService extends BaseService<Article> {
       if (patch.title !== article.title) {
         const existingSlugs = await this.getExistingSlugs(id);
         const title = patch.title || '';
-        const newSlug = createArticleSlug(title, existingSlugs, {
-          maxLength: 80,
-          separator: '-',
-        });
+        const newSlug =
+          createArticleSlug(title, existingSlugs, {
+            maxLength: 70,
+            separator: '-',
+          }) +
+          '.' +
+          globalSnowflake.nextId().toString() +
+          '.article';
         patch.slug = newSlug;
       }
     }


### PR DESCRIPTION
…ication

- Updated the slug generation logic in ArticlesService to include a unique identifier using globalSnowflake, ensuring that slugs are distinct and less likely to collide.
- Adjusted the maximum length of the slug to 70 characters for better compliance with URL standards while maintaining clarity.